### PR TITLE
Fixed white space below Navbar when viewing below 480px

### DIFF
--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -9,7 +9,6 @@ nav {
         padding: 1rem;
         color: white;
         text-decoration: none;
-        border-bottom:0.2rem solid transparent;
         
         @include media-phone {
             font-size: 16px;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -6,7 +6,7 @@
 
 body {
     margin: 0;
-    padding:  49.188px 0 0 0 ;
+    padding:  45px 0 0 0 ;
     color:#333;
       font-family: "Helvetica";
     -webkit-font-smoothing: antialiased;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -6,7 +6,7 @@
 
 body {
     margin: 0;
-    padding:  55px 0 0 0 ;
+    padding:  49.188px 0 0 0 ;
     color:#333;
       font-family: "Helvetica";
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Body had a padding of 50px which is more big than the nav bar which has a height of 49.188px. Made the padding of the body match the nav height.
issue #16 